### PR TITLE
Fix group model and resolver

### DIFF
--- a/functions/models/group.js
+++ b/functions/models/group.js
@@ -9,7 +9,9 @@ module.exports = model(
     groupCode: {
       type: String,
       default: function () {
-        const { name } = this;
+        const { name, course } = this;
+
+        if (course) return null;
         return `${name.replace(/\s+/g, "")}-${generateRandomString(10)}`;
       },
     },

--- a/functions/resolvers/groupResolvers.js
+++ b/functions/resolvers/groupResolvers.js
@@ -80,6 +80,8 @@ module.exports = {
       if (!(await isCourseTeacher(context.user.id, courseId)))
         throw Error("you must be the teacher of the course to create a class group");
 
+      if (!studentIds.length) throw Error("studentIds must not be empty");
+
       if (!(await isCourseStudentMulti(studentIds, courseId)))
         throw Error("all students must be a member of the course");
 


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- Fix `Group` model to not generate a groupcode when it is a class group
- `createClassGroup` resolver now doesnt allow empty `studentIds` 

## If there are changes to mutations and/or queries, give examples on how they will be used
