### PR TITLE
Add course and group query

### DIFF
--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -1,5 +1,5 @@
 const { Course, Teacher, CourseStudent, Student, Group } = require("../models/index.js");
-const { loginCheck } = require("../utils/checks.js");
+const { loginCheck, isCourseStudent, isCourseTeacher } = require("../utils/checks.js");
 
 module.exports = {
   Course: {
@@ -26,6 +26,15 @@ module.exports = {
   },
 
   Query: {
+    course: async (_, { courseId }, context) => {
+      loginCheck(context);
+
+      const userId = context.user.id;
+      if (!(await isCourseStudent(userId, courseId)) && !(await isCourseTeacher(userId, courseId)))
+        throw Error("not in course");
+
+      return await Course.findById(courseId);
+    },
     courses: async (_, { pagination }, context) => {
       loginCheck(context);
       const limit = pagination?.limit ?? 30;

--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -30,10 +30,13 @@ module.exports = {
       loginCheck(context);
 
       const userId = context.user.id;
-      if (!(await isCourseStudent(userId, courseId)) && !(await isCourseTeacher(userId, courseId)))
-        throw Error("not in course");
+      const course = await Course.findById(courseId);
+      if (!course) return null;
 
-      return await Course.findById(courseId);
+      const inCourse = (await isCourseStudent(userId, courseId)) || course.teacher == userId;
+      if (!inCourse) throw Error("not in course");
+
+      return course;
     },
     courses: async (_, { pagination }, context) => {
       loginCheck(context);

--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -1,5 +1,5 @@
 const { Course, Teacher, CourseStudent, Student, Group } = require("../models/index.js");
-const { loginCheck, isCourseStudent, isCourseTeacher } = require("../utils/checks.js");
+const { loginCheck, isCourseStudent } = require("../utils/checks.js");
 
 module.exports = {
   Course: {

--- a/functions/resolvers/groupResolvers.js
+++ b/functions/resolvers/groupResolvers.js
@@ -52,6 +52,17 @@ module.exports = {
   },
 
   Query: {
+    group: async (_, { groupId }, context) => {
+      loginCheck(context);
+
+      const userId = context.user.id;
+      const group = await Group.findById(groupId);
+
+      const allowedToQuery = (await isCourseTeacher(userId, group.course)) || (await isGroupStudent(userId, groupId));
+      if (!allowedToQuery) throw Error("can't query group");
+
+      return group;
+    },
     groups: async (_, { pagination }, context) => {
       loginCheck(context);
       const limit = pagination?.limit ?? 30;

--- a/functions/resolvers/groupResolvers.js
+++ b/functions/resolvers/groupResolvers.js
@@ -57,6 +57,7 @@ module.exports = {
 
       const userId = context.user.id;
       const group = await Group.findById(groupId);
+      if (!group) return null;
 
       const allowedToQuery = (await isCourseTeacher(userId, group.course)) || (await isGroupStudent(userId, groupId));
       if (!allowedToQuery) throw Error("can't query group");

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -19,6 +19,7 @@ module.exports = gql`
 
   # Group
   extend type Query {
+    group(groupId: ID!): Group
     groups(pagination: PaginationInput): GroupsResult
   }
 

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -13,6 +13,7 @@ module.exports = gql`
 
   # Course
   extend type Query {
+    course(courseId: ID!): Course
     courses(pagination: PaginationInput): CoursesResult
   }
 

--- a/functions/utils/checks.js
+++ b/functions/utils/checks.js
@@ -7,6 +7,8 @@ module.exports.loginCheck = (context) => {
 };
 
 module.exports.isCourseTeacher = async (teacherId, courseId) => {
+  if (!courseId) return false;
+
   const course = await Course.findById(courseId);
   return course.teacher == teacherId;
 };


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- adds `course` and `group` query

## If there are changes to mutations and/or queries, give examples on how they will be used
### `course` query example
```gql
query {
  course(courseId: "613baeecf7d3510f2f1b0682") {
    id
    name
  }
}
```
### `group` query example
```gql
query {
  group(groupId: "6142306e5f4dd2340624be6e") {
    id
    name
  }
}
```

