### PR TITLE
Add student class groups and student study groups queries

### DIFF
--- a/functions/resolvers/groupResolvers.js
+++ b/functions/resolvers/groupResolvers.js
@@ -83,6 +83,36 @@ module.exports = {
         },
       };
     },
+    studentClassGroups: async (_, __, context) => {
+      loginCheck(context);
+
+      const groupStudents = await GroupStudent.find({ student: context.user.id });
+      const filter = {
+        _id: {
+          $in: groupStudents?.map(({ group }) => group) ?? [],
+        },
+        course: { $exists: true },
+      };
+
+      return {
+        data: await Group.find(filter),
+      };
+    },
+    studentStudyGroups: async (_, __, context) => {
+      loginCheck(context);
+
+      const groupStudents = await GroupStudent.find({ student: context.user.id });
+      const filter = {
+        _id: {
+          $in: groupStudents?.map(({ group }) => group) ?? [],
+        },
+        course: { $exists: false },
+      };
+
+      return {
+        data: await Group.find(filter),
+      };
+    },
   },
 
   Mutation: {

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -46,6 +46,8 @@ module.exports = gql`
   extend type Query {
     group(groupId: ID!): Group
     groups(pagination: PaginationInput): GroupsResult
+    studentClassGroups(pagination: PaginationInput): GroupsResult
+    studentStudyGroups(pagination: PaginationInput): GroupsResult
   }
 
   # Feed


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `studentClassGroups` query
- add `studentStudyGroups` query

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
query {
  studentClassGroups {
    data {
      id
      name
    }
  }
}
```
```gql
query {
  studentStudyGroups {
    data {
      id
      name
    }
  }
}
```