### PR TITLE
added study group file resolver

### DIFF
--- a/functions/resolvers/fileResolvers.js
+++ b/functions/resolvers/fileResolvers.js
@@ -1,5 +1,5 @@
 const { Post, User, Activity, GroupActivity, Course } = require("../models/index.js");
-const { loginCheck, isCourseStudent } = require("../utils/checks");
+const { loginCheck, isCourseStudent, isGroupStudent } = require("../utils/checks");
 
 module.exports = {
   File: {
@@ -23,6 +23,21 @@ module.exports = {
         postFiles: await Post.find(filter).sort({ _id: -1 }),
         activityFiles: await Activity.find(filter).sort({ _id: -1 }),
         groupActivityFiles: await GroupActivity.find(filter).sort({ _id: -1 }),
+      };
+    },
+
+    studyGroupFiles: async (_, { groupId }, context) => {
+      loginCheck(context);
+
+      const userId = context.user.id;
+
+      const inGroup = await isGroupStudent(userId, groupId);
+      if (!inGroup) throw Error("not in group");
+
+      const filter = { group: groupId, attachment: { $exists: true } };
+
+      return {
+        postFiles: await Post.find(filter).sort({ _id: -1 }),
       };
     },
   },

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -38,12 +38,22 @@ module.exports = gql`
     groupPosts(groupId: ID!, tags: [String]): PostsResult
     groupPostTags(groupId: ID!): [Tag]
     coursePosts(courseId: ID!): PostsResult
-    courseFiles(courseId: ID!): CourseFilesResult
   }
 
   type Tag {
     name: String
     count: Int
+  }
+
+  # File
+  extend type Query {
+    studyGroupFiles(groupId: ID!): GroupFilesResult
+    courseFiles(courseId: ID!): CourseFilesResult
+  }
+
+  type GroupFilesResult {
+    postFiles: [File]
+    groupActivityFiles: [File]
   }
 
   type CourseFilesResult {


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?

Added query for displaying study group files from post

for example (pic based on class files, but it will output the same)
![image](https://user-images.githubusercontent.com/63730929/138836135-d177c0bb-2025-4ced-9cde-09aaadbd5016.png)


## If there are changes to mutations and/or queries, give examples on how they will be used

```gql 
query studyGroupFiles($groupId: ID!) {
  studyGroupFiles(groupId: $groupId) {
    postFiles {
      attachment
      user {
        firstName
        lastName
      }
    }
    groupActivityFiles {
      attachment
      user {
        firstName
        lastName
      }
    }
  }
}
```
