### PR TITLE
Add group submission stuff

### DIFF
--- a/functions/resolvers/activityResolvers.js
+++ b/functions/resolvers/activityResolvers.js
@@ -1,6 +1,15 @@
 const { validateAttachment } = require("../utils/cloudinary");
 
-const { Activity, Course, GroupActivity, Post, Submission } = require("../models/index.js");
+const {
+  Activity,
+  Course,
+  GroupActivity,
+  Post,
+  Submission,
+  Group,
+  GroupStudent,
+  GroupSubmission,
+} = require("../models/index.js");
 const { loginCheck, isCourseTeacher, isCourseStudent } = require("../utils/checks");
 
 module.exports = {
@@ -10,6 +19,16 @@ module.exports = {
   },
   GroupActivity: {
     course: async (groupActivity) => await Course.findById(groupActivity.course),
+    mySubmission: async ({ id, course }, _, context) => {
+      const groups = await Group.find({ course: course });
+      const groupStudent = await GroupStudent.findOne({
+        student: context.user.id,
+        group: { $in: groups },
+      });
+
+      if (!groupStudent) return null;
+      return await GroupSubmission.findOne({ groupActivity: id, group: groupStudent.group });
+    },
   },
 
   Query: {

--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -1,0 +1,40 @@
+const { GroupActivity, GroupStudent, GroupSubmission, Group } = require("../models/index.js");
+const { loginCheck } = require("../utils/checks");
+
+module.exports = {
+  GroupSubmission: {},
+
+  Query: {},
+
+  Mutation: {
+    createGroupSubmission: async (_, { groupActivityId }, context) => {
+      loginCheck(context);
+
+      const groupActivity = await GroupActivity.findById(groupActivityId);
+
+      if (!groupActivity) throw Error("group activity doesn't exist");
+
+      const groups = await Group.find({ course: groupActivity.course });
+      const groupStudent = await GroupStudent.findOne({
+        student: context.user.id,
+        group: { $in: groups },
+      });
+
+      if (!groupStudent) throw Error("you are not assigned to this group activity");
+      if (groupStudent.type !== "leader") throw Error("you are not the leader of the group");
+
+      const groupSubmission = await GroupSubmission.findOne({
+        groupActivity,
+        group: groupStudent.group,
+      });
+      if (groupSubmission) throw Error("already has submission in this activity");
+
+      const newGroupSubmission = new GroupSubmission({
+        groupActivity: groupActivityId,
+        group: groupStudent.group,
+      });
+
+      return await newGroupSubmission.save();
+    },
+  },
+};

--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -2,7 +2,10 @@ const { GroupActivity, GroupStudent, GroupSubmission, Group } = require("../mode
 const { loginCheck, isCourseTeacher, isGroupStudent } = require("../utils/checks");
 
 module.exports = {
-  GroupSubmission: {},
+  GroupSubmission: {
+    groupActivity: async ({ groupActivity }) => await GroupActivity.findById(groupActivity),
+    group: async ({ group }) => await Group.findById(group),
+  },
 
   Query: {
     groupSubmission: async (_, { groupSubmissionId }, context) => {

--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -1,10 +1,24 @@
 const { GroupActivity, GroupStudent, GroupSubmission, Group } = require("../models/index.js");
-const { loginCheck } = require("../utils/checks");
+const { loginCheck, isCourseTeacher } = require("../utils/checks");
 
 module.exports = {
   GroupSubmission: {},
 
-  Query: {},
+  Query: {
+    groupActivitySubmissions: async (_, { groupActivityId }, context) => {
+      loginCheck(context);
+
+      const groupActivity = await GroupActivity.findById(groupActivityId);
+      if (!(await isCourseTeacher(context.user.id, groupActivity.course)))
+        throw Error("you must be the teacher of the course to see all submissions");
+
+      const filter = { groupActivity: groupActivityId };
+
+      return {
+        data: await GroupSubmission.find(filter),
+      };
+    },
+  },
 
   Mutation: {
     createGroupSubmission: async (_, { groupActivityId }, context) => {

--- a/functions/resolvers/index.js
+++ b/functions/resolvers/index.js
@@ -16,6 +16,7 @@ const resolvers = [
   require("./groupResolvers.js"),
   require("./activityResolvers.js"),
   require("./submissionResolvers.js"),
+  require("./groupSubmissionResolvers.js"),
   require("./commentResolvers.js"),
   require("./fileResolvers.js"),
 ];

--- a/functions/typeDefs/mutation.js
+++ b/functions/typeDefs/mutation.js
@@ -47,12 +47,17 @@ module.exports = gql`
     addAttachmentToGroupActivity(id: ID!, attachment: String!): GroupActivity
   }
 
-  # Submission
+  # Submission / GroupSubmission
   extend type Mutation {
     createSubmission(description: String!, activityId: ID!): Submission
     addAttachmentToSubmission(id: ID!, attachment: String!): Submission
     submitSubmission(id: ID!): Submission
     gradeSubmission(submissionId: ID!, grade: Int!): Submission
+  }
+
+  # GroupSubmission
+  extend type Mutation {
+    createGroupSubmission(groupActivityId: ID!): GroupSubmission
   }
 
   # Post

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -107,6 +107,7 @@ module.exports = gql`
 
   # GroupSubmission
   extend type Query {
+    groupSubmission(groupSubmissionId: ID!): GroupSubmission
     groupActivitySubmissions(groupActivityId: ID!): GroupSubmissionsResult
   }
 `;

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -104,4 +104,9 @@ module.exports = gql`
     submission(submissionId: ID!): Submission
     activitySubmissions(activityId: ID!): SubmissionsResult
   }
+
+  # GroupSubmission
+  extend type Query {
+    groupActivitySubmissions(groupActivityId: ID!): GroupSubmissionsResult
+  }
 `;

--- a/functions/typeDefs/types.js
+++ b/functions/typeDefs/types.js
@@ -123,6 +123,7 @@ module.exports = gql`
     createdAt: Date
     course: Course
     submissions: GroupSubmissionsResult
+    mySubmission: GroupSubmission
     points: Int
   }
 


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `createGroupSubmission` mutation
- add `mySubmission` resolver to `groupActivity`
- add `groupActivitySubmissions` query
- add `groupSubmission` query

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
mutation {
  createGroupSubmission(groupActivityId: "617a4ac1820f0c00080c82e2") {
    id
  }
}

```
```gql
query {
  groupActivity(groupActivityId: "617a4ac1820f0c00080c82e2") {
    id
    mySubmission {
      id
    }
  }
}
```
```gql
query {
  groupActivitySubmissions(groupActivityId: "617a4ac1820f0c00080c82e2") {
    data {
      id
    }
  }
}
```
```gql
query {
  groupSubmission(groupSubmissionId: "617ed6617b4832767e5fffc9") {
    id
  }
}
```
