### PR TITLE
add myGroup resolver to Course

### DIFF
--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -24,6 +24,17 @@ module.exports = {
 
       return course.courseCode;
     },
+    myGroup: async ({ id }, _, context) => {
+      const groups = await Group.find({ course: id });
+      const groupStudent = await GroupStudent.findOne({
+        student: context.user.id,
+        group: { $in: groups },
+      });
+
+      if (!groupStudent) return null;
+
+      return await Group.findById(groupStudent.group);
+    },
   },
 
   Query: {

--- a/functions/typeDefs/types.js
+++ b/functions/typeDefs/types.js
@@ -60,6 +60,7 @@ module.exports = gql`
     startsAt: Date
     endsAt: Date
     isActive: Boolean
+    myGroup: Group
     groups: GroupsResult
     students: StudentsResult
     studentCount: Int


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `myGroup` resolver under `Course`

## If there are changes to mutations and/or queries, give examples on how they will be used
example of `myGroup`
```gql
query {
  groupActivity(groupActivityId: "617a4ac1820f0c00080c82e2") {
    id
    course {
      myGroup {
        leader {
          user {
            id
            firstName
          }
        }
      }
    }
    mySubmission {
      id
    }
  }
}
```