### PR TITLE
create submitGroupSubmission + other fields

### DIFF
--- a/functions/models/groupSubmission.js
+++ b/functions/models/groupSubmission.js
@@ -8,6 +8,7 @@ module.exports = model(
     grade: { type: Number, min: 0 },
     createdAt: { type: Date, default: Date.now },
     submittedAt: Date,
+    submittedBy: { type: Schema.Types.ObjectId, ref: "Student" },
     group: { type: Schema.Types.ObjectId, ref: "Group" },
     groupActivity: { type: Schema.Types.ObjectId, ref: "GroupActivity" },
 

--- a/functions/typeDefs/mutation.js
+++ b/functions/typeDefs/mutation.js
@@ -60,6 +60,7 @@ module.exports = gql`
   # GroupSubmission
   extend type Mutation {
     createGroupSubmission(groupActivityId: ID!): GroupSubmission
+    submitGroupSubmission(groupSubmissionId: ID!, description: String!, attachment: String): GroupSubmission
   }
 
   # Post

--- a/functions/typeDefs/types.js
+++ b/functions/typeDefs/types.js
@@ -156,6 +156,7 @@ module.exports = gql`
     grade: Int
     createdAt: Date
     submittedAt: Date
+    submittedBy: Student
     group: Group
     groupActivity: GroupActivity
     tasks: TasksResult


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `submitGroupSubmission` mutation
- add `submittedBy` field under `GroupSubmission`

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
mutation {
  submitGroupSubmission(
    groupSubmissionId: "61827939e08cd4000808a92d"
    description: "testing"
  ) {
    id
    description
    attachment
    submittedAt
    submittedBy {
      id
      user {
        id
        firstName
      }
    }
  }
}
```
