### PR TITLE
add groupSubmissionOfGroup query

### DIFF
--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -30,6 +30,19 @@ module.exports = {
 
       return groupSubmission;
     },
+    groupSubmissionOfGroup: async (_, { groupActivityId, groupId }, context) => {
+      loginCheck(context);
+
+      const groupActivity = await GroupActivity.findById(groupActivityId);
+
+      const allowedToQuery =
+        (await isCourseTeacher(context.user.id, groupActivity.course)) ||
+        (await isGroupStudent(context.user.id, groupId));
+
+      if (!allowedToQuery) throw Error("not allowed to query");
+
+      return await GroupSubmission.find({ groupActivity: groupActivityId, group: groupId });
+    },
     groupActivitySubmissions: async (_, { groupActivityId }, context) => {
       loginCheck(context);
 

--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -41,7 +41,7 @@ module.exports = {
 
       if (!allowedToQuery) throw Error("not allowed to query");
 
-      return await GroupSubmission.find({ groupActivity: groupActivityId, group: groupId });
+      return await GroupSubmission.findOne({ groupActivity: groupActivityId, group: groupId });
     },
     groupActivitySubmissions: async (_, { groupActivityId }, context) => {
       loginCheck(context);

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -108,6 +108,7 @@ module.exports = gql`
   # GroupSubmission
   extend type Query {
     groupSubmission(groupSubmissionId: ID!): GroupSubmission
+    groupSubmissionOfGroup(groupActivityId: ID!, groupId: ID!): GroupSubmission
     groupActivitySubmissions(groupActivityId: ID!): GroupSubmissionsResult
   }
 


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `groupSubmissionOfGroup` query

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
query {
  groupSubmissionOfGroup(groupActivityId: "6183b0f0a8640400087a73f6", groupId: "617d6b84546470000850410d") {
    id
    description
    attachment
    tasks {
      data {
        id
        student {
          id
          user {
            id
            firstName
          }
        }
      }
    }
    group {
      name
      students {
        data {
          id
          user {
            id
            firstName
          }
        }
      }
    }
  }
}
```
