### PR TITLE
add student and course in courseActivitiesAndSubmissions

### DIFF
--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -161,14 +161,15 @@ module.exports = {
           )
         ))();
 
-      const retVal = activities.map((activity, index) => ({
+      const activitiesAndSubmissions = activities.map((activity, index) => ({
         activity,
         submission: submissions[index],
       }));
 
       return {
+        course,
         student: await Student.findById(studentId),
-        data: retVal,
+        data: activitiesAndSubmissions,
       };
     },
   },

--- a/functions/resolvers/courseResolvers.js
+++ b/functions/resolvers/courseResolvers.js
@@ -166,7 +166,10 @@ module.exports = {
         submission: submissions[index],
       }));
 
-      return { data: retVal };
+      return {
+        student: await Student.findById(studentId),
+        data: retVal,
+      };
     },
   },
 

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -35,6 +35,7 @@ module.exports = gql`
   }
 
   type CourseActivitiesAndSubmissionsResult {
+    student: Student
     data: [ActivityAndSubmission]
   }
 

--- a/functions/typeDefs/query.js
+++ b/functions/typeDefs/query.js
@@ -35,6 +35,7 @@ module.exports = gql`
   }
 
   type CourseActivitiesAndSubmissionsResult {
+    course: Course
     student: Student
     data: [ActivityAndSubmission]
   }


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `student` and `course` in `courseActivitiesAndSubmissions`

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
query {
  courseActivitiesAndSubmissions(
    courseId: "613baeecf7d3510f2f1b0682"
    studentId: "613a16292f1da209e4520635"
  ) {
    course {
      id
      name
    }
    student {
      id
      user {
        firstName
      }
    }
    data {
      activity {
        id
        title
      }
      submission {
        id
        description
      }
    }
  }
}


```
