### PR TITLE
add gradeGroupSubmission mutation

### DIFF
--- a/functions/resolvers/groupSubmissionResolvers.js
+++ b/functions/resolvers/groupSubmissionResolvers.js
@@ -112,5 +112,22 @@ module.exports = {
 
       return await groupSubmission.save();
     },
+    gradeGroupSubmission: async (_, { groupSubmissionId, grade }, context) => {
+      loginCheck(context);
+
+      const groupSubmission = await GroupSubmission.findById(groupSubmissionId);
+      const groupActivity = await GroupActivity.findById(groupSubmission.groupActivity);
+      if (!(await isCourseTeacher(context.user.id, groupActivity.course)))
+        throw Error("you must be the teacher of the course to grade this submission");
+
+      if (!groupSubmission.submittedAt) throw Error("submission not yet final");
+
+      if (grade > groupActivity.points) throw Error("grade is higher than maximum");
+      if (grade < 0) throw Error("grade is negative");
+
+      groupSubmission.grade = grade;
+
+      return await groupSubmission.save();
+    },
   },
 };

--- a/functions/typeDefs/mutation.js
+++ b/functions/typeDefs/mutation.js
@@ -82,12 +82,10 @@ module.exports = gql`
     addAttachmentToSubmission(id: ID!, attachment: String!): Submission
     submitSubmission(id: ID!): Submission
     gradeSubmission(submissionId: ID!, grade: Int!): Submission
-  }
 
-  # GroupSubmission
-  extend type Mutation {
     createGroupSubmission(groupActivityId: ID!): GroupSubmission
     submitGroupSubmission(groupSubmissionId: ID!, description: String!, attachment: String): GroupSubmission
+    gradeGroupSubmission(groupSubmissionId: ID!, grade: Int!): GroupSubmission
   }
 
   # Post


### PR DESCRIPTION
<!-- Please fill in the below placeholders -->

## What does this PR do?
- add `gradeGroupSubmission` mutation

## If there are changes to mutations and/or queries, give examples on how they will be used
```gql
mutation {
  gradeGroupSubmission(groupSubmissionId: "617bcf07211ad9000a08b288", grade: 99) {
    id
    grade
  }
}
```